### PR TITLE
Update auto.cfg

### DIFF
--- a/auto.cfg
+++ b/auto.cfg
@@ -107,7 +107,7 @@ bind kp_8          "buy decoy;                 "    // 8
 bind kp_9          "                           "    // 9
 bind kp_0          "buy ak47;buy m4a1;         "    // 0
 bind kp_del        "                           "    // .
-// bind kp_slash      "                           "    // 失效？
+bind kp_divide     "                           "    // /
 bind kp_multiply   "                           "    // *
 bind kp_minus      "                           "    // -
 bind kp_plus       "                           "    // +


### PR DESCRIPTION
cs2中的kp_slash（小键盘斜杠）已失效，现已更名为kp_divide